### PR TITLE
Add ihg_usage_profile to PhxSupportiveDeviceParams (seasonal aux IHG)

### DIFF
--- a/PHX/from_HBJSON/create_hvac.py
+++ b/PHX/from_HBJSON/create_hvac.py
@@ -507,6 +507,7 @@ def build_phx_supportive_device(
     phx_device.params.norm_energy_demand_W = _hbph_supportive_device.norm_energy_demand_W
     phx_device.params.annual_period_operation_khrs = _hbph_supportive_device.annual_period_operation_khrs
     phx_device.params.ihg_utilization_factor = _hbph_supportive_device.ihg_utilization_factor
+    phx_device.params.ihg_usage_profile = _hbph_supportive_device.ihg_usage_profile
 
     return phx_device
 

--- a/PHX/model/hvac/supportive_devices.py
+++ b/PHX/model/hvac/supportive_devices.py
@@ -29,17 +29,32 @@ class PhxSupportiveDeviceParams(_base.PhxMechanicalDeviceParams):
         annual_period_operation_khrs (float): Annual operating period (kilo-hours). Default: 8.760.
         ihg_utilization_factor (float): Internal heat gains utilization factor (0.0-1.0).
             Default: 1.0.
+        ihg_usage_profile (int): PHPP season/block the device's IHG lands in
+            (1=all-year, 2=winter, 3=summer, 4=none/DHW). Carried verbatim from the
+            Honeybee-PH ``PhSupportiveDevice`` so downstream tools (OpenPH) can route
+            the device into the correct Aux-Electricity worksheet block. Default: 1.
     """
 
     in_conditioned_space: bool = True
     norm_energy_demand_W: float = 1.0
     annual_period_operation_khrs: float = 8.760
     ihg_utilization_factor: float = 1.0
+    ihg_usage_profile: int = 1
 
     def __add__(self, other: PhxSupportiveDeviceParams) -> PhxSupportiveDeviceParams:
         base = super().__add__(other)
         new_obj = self.__class__(**vars(base))
         new_obj.in_conditioned_space = any([self.in_conditioned_space, other.in_conditioned_space])
+
+        # -- Devices only merge when they share an identifier (same logical device),
+        # -- so their IHG season/block must match; a mismatch is corrupt data. Raise
+        # -- loudly, matching PhxSupportiveDevice.__add__'s raise on device_type.
+        if self.ihg_usage_profile != other.ihg_usage_profile:
+            raise ValueError(
+                "Cannot merge supportive devices with different ihg_usage_profile: "
+                f"{self.ihg_usage_profile} and {other.ihg_usage_profile}."
+            )
+        new_obj.ihg_usage_profile = self.ihg_usage_profile
 
         # -- Merge the energy usage and hours of operation
         total_kilohours = self.annual_period_operation_khrs + other.annual_period_operation_khrs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "honeybee-core>=1.64.9",
     "honeybee-energy>=1.116.103",
-    "honeybee-ph>=1.33.22",
+    "honeybee-ph>=1.33.27",
     "pydantic>=2.0",
     "PH-units>=1.5.26",
     "rich",

--- a/tests/test_from_HBJSON/test_create_hvac/test_build_supportive_device.py
+++ b/tests/test_from_HBJSON/test_create_hvac/test_build_supportive_device.py
@@ -23,3 +23,25 @@ class TestBuildPhxSupportiveDeviceIHGFactor:
         # default is 1.0 on both sides
         phx_device = build_phx_supportive_device(hb_device)
         assert phx_device.params.ihg_utilization_factor == 1.0
+
+
+class TestBuildPhxSupportiveDeviceIHGUsageProfile:
+    def test_maps_ihg_usage_profile_default(self, reset_class_counters):
+        # -- default device_type (10-Other) seeds ihg_usage_profile = 1 (ALL_YEAR)
+        hb_device = PhSupportiveDevice()
+        phx_device = build_phx_supportive_device(hb_device)
+        assert phx_device.params.ihg_usage_profile == 1
+
+    def test_maps_ihg_usage_profile_explicit(self, reset_class_counters):
+        # -- an explicit WINTER tag (2) must be set AFTER device_type (the setter re-seeds)
+        hb_device = PhSupportiveDevice()
+        hb_device.ihg_usage_profile = 2
+        phx_device = build_phx_supportive_device(hb_device)
+        assert phx_device.params.ihg_usage_profile == 2
+
+    def test_maps_ihg_usage_profile_dhw_default(self, reset_class_counters):
+        # -- a DHW circulation pump (type 6) re-seeds to 4 (NONE) via the property setter
+        hb_device = PhSupportiveDevice()
+        hb_device.device_type = 6
+        phx_device = build_phx_supportive_device(hb_device)
+        assert phx_device.params.ihg_usage_profile == 4

--- a/tests/test_model/test_hvac/test_supportive_device.py
+++ b/tests/test_model/test_hvac/test_supportive_device.py
@@ -100,6 +100,35 @@ class TestPhxSupportiveDeviceParamsIHGFactor:
         assert merged.ihg_utilization_factor == pytest.approx(0.5)
 
 
+# ---------------------------------------------------------------------------
+# --- IHG Usage Profile (PHPP season/block)
+# ---------------------------------------------------------------------------
+
+
+class TestPhxSupportiveDeviceParamsIHGUsageProfile:
+    def test_default_ihg_usage_profile(self, reset_class_counters):
+        params = PhxSupportiveDeviceParams()
+        assert params.ihg_usage_profile == 1
+
+    def test_set_ihg_usage_profile(self, reset_class_counters):
+        params = PhxSupportiveDeviceParams(ihg_usage_profile=2)
+        assert params.ihg_usage_profile == 2
+
+    def test_add_params_same_profile_preserves_it(self, reset_class_counters):
+        """Merging two same-profile params keeps that profile."""
+        p1 = PhxSupportiveDeviceParams(norm_energy_demand_W=100, ihg_usage_profile=2)
+        p2 = PhxSupportiveDeviceParams(norm_energy_demand_W=50, ihg_usage_profile=2)
+        merged = p1 + p2
+        assert merged.ihg_usage_profile == 2
+
+    def test_add_params_different_profile_raises(self, reset_class_counters):
+        """Same-identifier devices must share a profile; a mismatch is corrupt data."""
+        p1 = PhxSupportiveDeviceParams(ihg_usage_profile=2)
+        p2 = PhxSupportiveDeviceParams(ihg_usage_profile=1)
+        with pytest.raises(ValueError):
+            _ = p1 + p2
+
+
 class TestPhxSupportiveDeviceIHGFactor:
     def test_device_default_ihg_utilization_factor(self, reset_class_counters):
         device = PhxSupportiveDevice()

--- a/uv.lock
+++ b/uv.lock
@@ -256,16 +256,16 @@ wheels = [
 
 [[package]]
 name = "honeybee-ph"
-version = "1.33.21"
+version = "1.33.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "honeybee-core" },
     { name = "honeybee-energy" },
     { name = "ph-units" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/2e/0b54241ead0114ce6c0de2a10a4979cad946a15a9b8cb6ab0f6d2fc156bf/honeybee_ph-1.33.21.tar.gz", hash = "sha256:b73e325d2dce9880883d070ce9e229228e6d86f0f824aef9da1f6dcee5175d93", size = 144169, upload-time = "2026-07-02T17:00:32.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/f6/e9234747d1156c74d48826a14b9bee48fd7edc9611960dff381f1a374b87/honeybee_ph-1.33.27.tar.gz", hash = "sha256:4507a7439c082251629e98a6d289876cf9ec96db51e0bb475298985f9fed52e4", size = 145669, upload-time = "2026-07-07T02:49:35.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/b0/0b51ce53fd2280a7cee0181bdbdba19bf08558b7e8dd9b4a306ac298d76e/honeybee_ph-1.33.21-py3-none-any.whl", hash = "sha256:41fcea24c4e6a8921fd4c8aa608467cef5495624bda80cf55c6b977055b5b087", size = 196072, upload-time = "2026-07-02T17:00:31.024Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/87/f89299fc543ad70e0460f79710a388e7bc91b1808b4173a269e31956c55c/honeybee_ph-1.33.27-py3-none-any.whl", hash = "sha256:2dfb11b0a3c93c4dd21941fb848e3af3aa3bff7ae05d7871732e9dd5a10d4799", size = 197618, upload-time = "2026-07-07T02:49:33.48Z" },
 ]
 
 [[package]]
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "phx"
-version = "1.56.51"
+version = "1.56.56"
 source = { editable = "." }
 dependencies = [
     { name = "honeybee-core" },
@@ -554,7 +554,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "honeybee-core", specifier = ">=1.64.9" },
     { name = "honeybee-energy", specifier = ">=1.116.103" },
-    { name = "honeybee-ph", specifier = ">=1.33.21" },
+    { name = "honeybee-ph", specifier = ">=1.33.27" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "lxml" },
     { name = "ph-units", specifier = ">=1.5.26" },


### PR DESCRIPTION
Carry the honeybee-ph supportive-device IHG season/block int through PHX so downstream OpenPH can route each aux device into the correct PHPP Aux-Electricity worksheet block (aux-electricity-seasonal-ihg Phase 02b, Part 1).

- PhxSupportiveDeviceParams.ihg_usage_profile: int = 1 (1=all-year, 2=winter, 3=summer, 4=none/DHW); mapped in create_hvac.build_phx_supportive_device.
- __add__ raises on a profile mismatch: devices merge only when they share an identifier (the same logical device), so a mismatch is corrupt data -- matching the existing raise on device_type in PhxSupportiveDevice.__add__.
- Bump honeybee-ph floor to >=1.33.27 (the release carrying the field) + relock.

Tests: profile mapping (default / explicit / DHW re-seed), __add__ same-profile preserves + mismatch raises. Full suite 629 passed / 3 skipped.