### PR TITLE
fix(xl): address PR #74 review notes (anchor-cell parsing, NaN handling, replay-fixture guard)

### DIFF
--- a/PHX/xl/xl_app.py
+++ b/PHX/xl/xl_app.py
@@ -654,15 +654,21 @@ class XLConnection:
     def _use_raw_write(self, _xl_item: xl_data.XlItem | xl_data.XLItem_List) -> bool:
         """Return True if the item can be written through the fast 'raw_value' path.
 
-        On macOS the xlwings '.value' converter layer adds ~5x per write (and
-        far more on 2D blocks) on top of the AppleEvent cost, so plain data
+        The xlwings '.value' converter layer adds ~5x per write (and far more
+        on 2D blocks) on top of the AppleEvent cost on macOS, so plain data
         writes go through 'range.raw_value' with the shaping done Python-side
         ('xl_data.prepare_raw_write'). Items that rely on converter behavior
         stay on the '.value' path: colored items (the color-write offsets are
         anchored to the converter's range), multi-cell target addresses
         (which use '.value' scalar-broadcast, ie: block-clears), and empty
-        lists (which the converter silently skips). On Windows the COM
-        backend expects different raw shapes - it keeps '.value' throughout.
+        lists (which the converter silently skips).
+
+        Only Windows is excluded (its COM backend expects different raw
+        shapes). Everything else - macOS in production, plus the Linux CI
+        runners driving the in-memory fakes - takes the raw path, which is
+        deliberate: it keeps CI exercising the exact write path that ships
+        on macOS. Live Excel never runs on Linux, so no real workbook is
+        ever written there.
         """
         if self.os_is_windows:
             return False

--- a/PHX/xl/xl_data.py
+++ b/PHX/xl/xl_data.py
@@ -73,14 +73,21 @@ class XlItem:
         self.font_color = font_color
 
     @property
+    def xl_anchor_cell(self) -> str:
+        """The range's top-left (anchor) cell. ie: 'A1:D10' -> 'A1', 'L41' -> 'L41'."""
+        return self.xl_range.split(":")[0]
+
+    @property
     def xl_row_number(self) -> int:
+        # -- Parse the anchor cell only: joining digits across a multi-cell
+        # -- range would fold the end-row in (ie: 'A1:D10' -> 110).
         # -- Note: was previously int(first-digit-char), so 'L41' gave 4 and
         # -- 'L41' vs 'L48' compared as the same row in merge_xl_item_row.
-        return int("".join(_ for _ in self.xl_range if _.isdigit()))
+        return int("".join(_ for _ in self.xl_anchor_cell if _.isdigit()))
 
     @property
     def xl_col_number(self) -> int:
-        return xl_ord(self.xl_range)
+        return xl_ord(self.xl_anchor_cell)
 
     @property
     def xl_col_alpha(self) -> str:

--- a/scripts/perf/readback_verify.py
+++ b/scripts/perf/readback_verify.py
@@ -151,11 +151,15 @@ def _as_number(value: Value) -> float | None:
     if isinstance(value, bool) or value is None:
         return None
     if isinstance(value, (int, float)):
-        return float(value)
-    try:
-        return float(str(value).strip())
-    except (ValueError, TypeError):
-        return None
+        number = float(value)
+    else:
+        try:
+            number = float(str(value).strip())
+        except (ValueError, TypeError):
+            return None
+    # -- NaN/inf are non-numbers here: a NaN would poison 'block_sum' totals,
+    # -- and NaN != NaN would make 'compare()' flag two equivalent extracts.
+    return number if math.isfinite(number) else None
 
 
 def _block_values(reader: WorkbookReader, entry: dict) -> list[Value]:
@@ -260,6 +264,14 @@ def compare(a: dict[str, Any], b: dict[str, Any], rtol: float = 1e-6, atol: floa
             diffs.append(f"'{key}': missing from second extract")
             continue
         va, vb = a[key], b[key]
+        # -- NaN floats can round-trip through the JSON extracts; NaN != NaN,
+        # -- so compare them by NaN-ness instead of equality.
+        va_nan = isinstance(va, float) and math.isnan(va)
+        vb_nan = isinstance(vb, float) and math.isnan(vb)
+        if va_nan or vb_nan:
+            if not (va_nan and vb_nan):
+                diffs.append(f"'{key}': {va!r} != {vb!r}")
+            continue
         na, nb = _as_number(va), _as_number(vb)
         if na is not None and nb is not None:
             if not math.isclose(na, nb, rel_tol=rtol, abs_tol=atol):

--- a/tests/test_PHPP/test_xl_data_XlItem.py
+++ b/tests/test_PHPP/test_xl_data_XlItem.py
@@ -45,3 +45,20 @@ def test_XlItem_covert_FT():
 def test_XlItem_list():
     item = xl_data.XlItem("sheet_1", "A1", [1, 2, 3, 4], "FT", "FT")
     assert item.write_value == [1, 2, 3, 4]
+
+
+def test_XlItem_row_and_col_numbers_parse_the_anchor_cell_only():
+    # -- single-cell anchors
+    item = xl_data.XlItem("sheet_1", "L41", None)
+    assert item.xl_anchor_cell == "L41"
+    assert item.xl_row_number == 41
+    assert item.xl_col_number == xl_data.xl_ord("L")
+    assert item.xl_col_alpha == "L"
+
+    # -- multi-cell ranges (ie: block-clears) must not fold the end-cell in:
+    # -- 'A1:D10' previously gave row 110 and a column blended from 'A' + 'D'.
+    item = xl_data.XlItem("sheet_1", "A1:D10", None)
+    assert item.xl_anchor_cell == "A1"
+    assert item.xl_row_number == 1
+    assert item.xl_col_number == xl_data.xl_ord("A")
+    assert item.xl_col_alpha == "A"

--- a/tests/test_scripts_perf/test_readback_verify.py
+++ b/tests/test_scripts_perf/test_readback_verify.py
@@ -290,6 +290,27 @@ def test_compare_numeric_string_vs_number():
     assert readback_verify.compare({"n": "42.0"}, {"n": 42}) == []
 
 
+def test_as_number_rejects_nan_and_inf():
+    # -- 'NaN'/'inf' text float-parses, but a NaN would poison block_sum totals
+    # -- and NaN != NaN would make compare() flag two equivalent extracts.
+    assert readback_verify._as_number("NaN") is None
+    assert readback_verify._as_number("inf") is None
+    assert readback_verify._as_number(float("nan")) is None
+    assert readback_verify._as_number(42) == 42.0
+
+
+def test_compare_treats_nan_values_as_plain_text():
+    # -- two 'NaN' cells fall through to the non-numeric equality check
+    assert readback_verify.compare({"n": "NaN"}, {"n": "NaN"}) == []
+    assert len(readback_verify.compare({"n": "NaN"}, {"n": 1.0})) == 1
+
+
+def test_compare_nan_floats_match_each_other_but_not_numbers():
+    nan = float("nan")
+    assert readback_verify.compare({"n": nan}, {"n": nan}) == []
+    assert len(readback_verify.compare({"n": nan}, {"n": 1.0})) == 1
+
+
 def test_compare_reports_missing_keys_and_mismatches():
     diffs = readback_verify.compare({"a": 1, "b": "x"}, {"b": "y", "c": 3})
     assert len(diffs) == 3  # 'a' missing from second, 'b' mismatch, 'c' missing from first

--- a/tests/test_xl_replay/test_replay_invariant.py
+++ b/tests/test_xl_replay/test_replay_invariant.py
@@ -20,8 +20,6 @@ To (re-)record the fixture: 'python scripts/perf/record_replay_fixture.py'.
 import json
 import pathlib
 
-import pytest
-
 from PHX.from_HBJSON import create_project, read_HBJSON_file
 from PHX.hbjson_to_phpp import write_phx_project_to_phpp
 from PHX.PHPP import phpp_app
@@ -49,8 +47,13 @@ def _diff_cell_states(result: dict, golden: dict) -> list[str]:
     return diffs
 
 
-@pytest.mark.skipif(not FIXTURE_FILE.exists(), reason="Replay fixture has not been recorded yet.")
 def test_full_export_replay_matches_golden_cell_state(reset_class_counters) -> None:
+    # -- Fail (never skip) if the fixture is missing: a silent skip would turn
+    # -- off the write-path regression gate without anyone noticing in CI.
+    assert FIXTURE_FILE.exists(), (
+        f"Replay fixture not found: {FIXTURE_FILE}. It is versioned in-repo; "
+        "re-record with 'python scripts/perf/record_replay_fixture.py' if it was removed intentionally."
+    )
     fixture = json.loads(FIXTURE_FILE.read_text())
 
     # -- Build the reference PhxProject (deterministic: counters are reset).


### PR DESCRIPTION
Follow-ups from the Copilot review on #74 (https://github.com/PH-Tools/PHX/pull/74#pullrequestreview-4704166626):

- **`XlItem.xl_row_number` / `xl_col_number`**: parse the anchor cell only (`"A1:D10"` → row 1, col A — previously would have folded the end cell in: row 110). Latent — no current call path evaluates these on multi-cell ranges (the mergers only see anchor-cell items and `prepare_raw_write` is guarded), but now defended + tested.
- **Replay invariant test**: fails with a clear message instead of skipping if the versioned fixture is missing, so the write-path regression gate can never silently go dark in CI.
- **`readback_verify`**: `"NaN"`/`"inf"` text and NaN floats are treated as non-numeric (`block_sum` can't be poisoned), and `compare()` matches NaN floats by NaN-ness instead of `!=`.
- **`_use_raw_write` docstring**: now states the actual gate — only Windows is excluded; Linux CI runners driving the in-memory fakes deliberately take the raw path so CI exercises the exact write path that ships on macOS. (Reviewer suggested gating to darwin; that would flip CI onto the legacy `.value` path and gut raw-path coverage, so behavior is unchanged on purpose.)

741 tests passing (the 3 remaining skips are pre-existing PPP-example-file skips, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)