### PR TITLE
Fix: parse the PHPP version of an easyPH workbook

### DIFF
--- a/PHX/PHPP/phpp_app.py
+++ b/PHX/PHPP/phpp_app.py
@@ -140,6 +140,9 @@ class PHPPConnection:
         # ---------------------------------------------------------------------
         # -- Find the right Version number
         raw_version_id: str = str(data[1])  # Use the second value in the row - data (will this always work?)
+        # -- easyPH workbooks tag the edition onto the version ("10.6 easyPHv3 IP").
+        # -- They share their base version's shapefile, so drop the tag before parsing.
+        raw_version_id = version.strip_easyph_edition_tag(raw_version_id)
         ver_major, ver_minor = raw_version_id.split(".")
 
         # ---------------------------------------------------------------------

--- a/PHX/PHPP/phpp_model/version.py
+++ b/PHX/PHPP/phpp_model/version.py
@@ -2,6 +2,32 @@
 
 """Class for managing PHPP Version data."""
 
+import re
+
+# -- easyPH workbooks append an edition tag to the version string on 'Data', eg:
+# --     "10.6 easyPHv3"      (SI)
+# --     "10.6 easyPHv3 IP"   (IP)
+# -- while a standard PHPP reads "10.6" or "10.6 IP". The tag identifies the easyPH
+# -- edition, not a different shapefile: easyPH is a standard PHPP plus an 'easyPH'
+# -- input worksheet, so it uses the same localization shape as its base version.
+EASYPH_EDITION_TAG = re.compile(r"\s*easyPH\s*v?\d*(?:\.\d+)*\s*", re.IGNORECASE)
+
+
+def strip_easyph_edition_tag(_raw_version_id: str) -> str:
+    """Remove any 'easyPH' edition tag from a raw PHPP version string.
+
+    Leaves everything else untouched, so the unit-system suffix that selects the
+    shapefile survives:
+
+        "10.6 easyPHv3"     -> "10.6"        -> EN_10_6.json
+        "10.6 easyPHv3 IP"  -> "10.6 IP"     -> EN_10_6IP.json
+        "10.6"              -> "10.6"        (unchanged)
+
+    Without this, `PHPPVersion` builds a `number_minor` of "6EASYPHV3" and the
+    shapefile lookup fails on a filename that does not exist.
+    """
+    return EASYPH_EDITION_TAG.sub(" ", str(_raw_version_id)).strip()
+
 
 class PHPPVersion:
     """Manage the PHPP Version number and language information."""

--- a/tests/test_PHPP/test_phpp_version.py
+++ b/tests/test_PHPP/test_phpp_version.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from PHX.PHPP.phpp_localization.load import get_shape_filepath
+from PHX.PHPP.phpp_model.version import PHPPVersion, strip_easyph_edition_tag
+
+
+@pytest.mark.parametrize(
+    "raw_version_id,expected",
+    [
+        # -- easyPH tags the edition onto the version string on the 'Data' worksheet
+        ("10.6 easyPHv3", "10.6"),
+        ("10.6 easyPHv3 IP", "10.6 IP"),
+        ("10.6easyPHv3", "10.6"),
+        ("10.6 EASYPHV3", "10.6"),
+        ("10.6 easyPH", "10.6"),
+        # -- standard PHPP version strings are left alone
+        ("10.6", "10.6"),
+        ("10.6 IP", "10.6 IP"),
+        ("10.4A", "10.4A"),
+        ("9.6a", "9.6a"),
+    ],
+)
+def test_strip_easyph_edition_tag(raw_version_id, expected) -> None:
+    assert strip_easyph_edition_tag(raw_version_id) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_version_id,expected_minor",
+    [
+        ("10.6 easyPHv3", "6"),
+        ("10.6 easyPHv3 IP", "6IP"),
+    ],
+)
+def test_easyph_version_parses_to_its_base_version(raw_version_id, expected_minor) -> None:
+    """An easyPH workbook must resolve to its base PHPP version, not to a new one.
+
+    Without stripping the tag, `number_minor` becomes "6EASYPHV3" and the shapefile
+    lookup asks for a file that does not exist.
+    """
+    ver_major, ver_minor = strip_easyph_edition_tag(raw_version_id).split(".")
+    phpp_version = PHPPVersion(ver_major, ver_minor, "EN")
+
+    assert phpp_version.number_major == "10"
+    assert phpp_version.number_minor == expected_minor
+
+
+@pytest.mark.parametrize(
+    "raw_version_id",
+    [
+        "10.6 easyPHv3",
+        "10.6 easyPHv3 IP",
+    ],
+)
+def test_easyph_versions_resolve_to_a_real_shape_file(raw_version_id) -> None:
+    """The end-to-end failure this fixes: an easyPH workbook raised FileNotFoundError
+    from `get_shape_filepath` before any read or write could happen."""
+    ver_major, ver_minor = strip_easyph_edition_tag(raw_version_id).split(".")
+    phpp_version = PHPPVersion(ver_major, ver_minor, "EN")
+
+    shape_file_dir = Path("PHX", "PHPP", "phpp_localization")
+
+    assert get_shape_filepath(phpp_version, shape_file_dir).exists()


### PR DESCRIPTION
`PHPPConnection.get_phpp_version()` raises `FileNotFoundError` on any easyPH workbook, before a single cell is read or written.

easyPH appends an edition tag to the version string on the 'Data' worksheet:

    standard PHPP   Data!B5 = "10.6"           /  "10.6 IP"
    easyPH          Data!B5 = "10.6 easyPHv3"  /  "10.6 easyPHv3 IP"

`raw_version_id.split(".")` therefore yields a minor of `"6 easyPHv3"`, which `PHPPVersion.clean_input` normalises to `"6EASYPHV3"`, and `get_shape_filepath()` goes looking for `EN_10_6EASYPHV3.json` — a shapefile that does not and should not exist.

The tag identifies the edition, not a different shape. An easyPH file is a standard PHPP plus an `easyPH` input worksheet: same sheets, same cell geometry, same localization. PHX already recognises this elsewhere — `PHPPConnection.is_easyPh()` detects the edition by looking for the worksheet, not by reading the version string — so dropping the tag before parsing loses nothing.

`strip_easyph_edition_tag()` removes only that tag, leaving the rest of the string intact so the unit-system suffix still selects the right shapefile:

    "10.6 easyPHv3"     -> "10.6"      -> EN_10_6.json
    "10.6 easyPHv3 IP"  -> "10.6 IP"   -> EN_10_6IP.json
    "10.6"              -> "10.6"      (unchanged)

Verified against two real PHI workbooks — a v10.6 EN easyPH project file and the v10.6 IP easyPH beta V.3 blank — both of which now resolve to their correct existing shapefiles. Full tests/test_PHPP suite passes (169).